### PR TITLE
Change numpy import to avoid sphinx adding numpy docs

### DIFF
--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import cirq
 from cirq.circuits import Circuit
-from numpy.random import choice, randint
 import numpy as np
 from typing import List, Tuple, Optional, Union
 
@@ -74,7 +73,7 @@ def generate_training_circuits(
     if isinstance(random_state, int):
         random_state = np.random.RandomState(random_state)
     else:
-        random_state = randint(10 ** (8))
+        random_state = np.random.ranint(10 ** (8))
         random_state = np.random.RandomState(random_state)
     # generating a list of seeds used for each training circuit construction:
     random_states = random_state.randint(
@@ -399,7 +398,7 @@ def _closest_clifford(ang: float) -> float:
     # cliff gate to return.
     else:
         index_list = [ang_scaled - 0.5, ang_scaled + 0.5]
-        index = int(choice(index_list))
+        index = int(np.random.choice(index_list))
         return CLIFFORD_ANGLES[index]
 
 


### PR DESCRIPTION
Changing this import fixes the issue where numpy examples were being somehow pulled into your doc.

Don't ask me why this was happening, maybe you could open an issue with numpy or Sphinx 🤷‍♂️ 

See here: https://github.com/unitaryfund/mitiq/pull/601/checks?check_run_id=2325161030
```sh
Document: apidoc
----------------
/opt/hostedtoolcache/Python/3.8.8/x64/lib/python3.8/site-packages/pyquil/api/_compiler.py:480: UserWarning: Request to quilc at tcp://127.0.0.1:5555 timed out. This could mean that quilc is not running, is not reachable, or is responding slowly.. Compilation using quilc will not be available.
  warnings.warn(f"{e}. Compilation using quilc will not be available.")

Warning, treated as error:
**********************************************************************
File "../../mitiq/cdr/clifford_training_data.py", line ?, in default
Failed example:
    np.random.choice(5, 3)
Expected:
    array([0, 3, 4]) # random
Got:
    array([0, 2, 3])

make[1]: *** [Makefile:20: doctest] Error 2
make: *** [Makefile:43: doctest] Error 2
make[1]: Leaving directory '/home/runner/work/mitiq/mitiq/docs'
Error: Process completed with exit code 2.
```